### PR TITLE
Fix authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                     <input type="password" id="pat" onchange="setLoc('pat', this.value)">
                     <label for="repo">Repo (format: user/reponame):</label>
                     <div class="m-select">
-                        <select id="repo" onchange="setLoc('repo', this.value);drop(`https://api.github.com/repos/${localStorage.getItem('repo')}/issues`, 'isnum', 'number');"></select>
+                        <select id="repo" onchange="setLoc('repo', this.value);"></select>
                         <div class="m-sel"></div>
                     </div>
                     <label for="isnum">Issue #:</label>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                         <select id="isnum" onchange="setLoc('isnum', this.value);delBms();getBm();"></select>
                         <div class="m-sel"></div>
                     </div>
-                    <a href="https://github.com/apps/matter-a-minimal-rss-reader/installations/new" target="_blank" rel="noreferrer"><button>Log in w/ GitHub</button></a>
+                    <a href="https://github.com/login/oauth/authorize?client_id=Iv1.3f4fb1ba73a1a737" target="_blank" rel="noreferrer" id="login-btn"><button>Log in w/ GitHub</button></a>
                     <hr>
                 </details>
                 <label for="newurl">New URL to bookmark:</label>

--- a/main.js
+++ b/main.js
@@ -22,12 +22,7 @@ var pat, repo, isnum = null;
 
 rerender();
 
-if (localStorage.getItem("pat") != null) {
-    drop("https://api.github.com/user/repos", "repo", "full_name");
-    if (localStorage.getItem("repo") != null) {
-        drop(`https://api.github.com/repos/${localStorage.getItem('repo')}/issues`, 'isnum', 'number');
-    }
-}
+drops();
 document.getElementById("repo").value = localStorage.getItem("repo");
 document.getElementById("isnum").value = localStorage.getItem("isnum");
 
@@ -36,6 +31,15 @@ function toURL(val) {
     if (document.getElementById("sources").value != RSSES.join(",")) {
         window.location.hash = btoa(val);
         window.location.reload();
+    }
+}
+
+function drops() {
+    if (localStorage.getItem("pat") != null) {
+        drop("https://api.github.com/user/repos", "repo", "full_name");
+        if (localStorage.getItem("repo") != null) {
+            drop(`https://api.github.com/repos/${localStorage.getItem('repo')}/issues`, 'isnum', 'number');
+        }
     }
 }
 
@@ -49,6 +53,7 @@ function setLoc(name, val) {
     if (document.getElementById(name)) {
         localStorage.setItem(name, val);
     }
+    drops();
 }
 
 function showEr(er) {

--- a/main.js
+++ b/main.js
@@ -154,8 +154,7 @@ function addItem(ln, title, desc, id) {
         var descTrun = desc ? (desc.length > 50 ? `${desc.slice(0, 50)}...` : desc) : "";
         const linkId = " <a onclick='delBm(" + id + ")'>[delete]</a>";
         // if description does exist => if id, then bookmark, add delete. If not, add the truncated description.
-        // if description does not exist => if id, then bookmark, add delete. Otherwise, set to empty.
-        clone.querySelector("p").innerHTML = desc != undefined ? (id != undefined ? (descTrun + linkId) : descTrun) : (id != undefined ? linkId : "");
+        // if description does not exist => if id, then bookmark, add delete. Otherwise, set to empty.  clone.querySelector("p").innerHTML = desc != undefined ? (id != undefined ? (descTrun + linkId) : descTrun) : (id != undefined ? linkId : "");
     }
     main.appendChild(clone);
 }
@@ -216,6 +215,9 @@ function parseFeed(feed) {
     });
 }
 
+if (pat) {
+    document.getElementById("login-btn").style.display = "none"; 
+}
 if (pat && repo && isnum) {
     getBm();
 }

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const CORSURL = 'https://matter-cors.herokuapp.com';
 const urlstring = atob(window.location.hash.substring(1)).split(",");
 const urlloc = JSON.parse(localStorage.getItem("sources"));
 // looks at the current url, if it doesn't exist, then fall back to localStorage. If not, then set to default RSS.
-var RSSES = (urlstring && urlstring.indexOf("") == -1) ? urlstring : (urlloc.indexOf("") == -1 ? urlloc : ["https://kewbi.sh/blog/index.xml"]);
+var RSSES = (urlstring && urlstring.indexOf("") == -1) ? urlstring : (urlloc && urlloc.indexOf("") == -1 ? urlloc : ["https://kewbi.sh/blog/index.xml"]);
 
 document.getElementById("er").style.display = "none";
 document.getElementById("sources").value = RSSES;


### PR DESCRIPTION
This PR:
- Fixes the indexOf null issue initializing a new Matter instance, where `urlloc` wasn't set. Now checks that `urlloc` exists before trying anything fancy.
- Fixes out-of-order dropdown building, and fixes dropdown builds not starting after the previous bit of information was added. For example, when `repo` was added to localStorage, the issue dropdown wouldn't render. On page reload, it would duplicate the issue numbers as well. This now ensures that the repo dropdown is populated when the PAT is collected, and the same for the issue number dropdown.
- Fixes the GitHub App auth issue where the app wouldn't actually redirect and collect a token.